### PR TITLE
fix(scoping): add back button for specific flow

### DIFF
--- a/src/features/scoping/pages/session-scoping/session-scoping.component.html
+++ b/src/features/scoping/pages/session-scoping/session-scoping.component.html
@@ -1,7 +1,13 @@
 <ion-header>
-  <ion-navbar>
-    <ion-title>Scoping Session</ion-title>
-  </ion-navbar>
+  <ion-toolbar>
+    <ion-buttons>
+      <button ion-button icon-only (click)="goDashboard()">
+        <ion-icon name="arrow-back"></ion-icon>
+      </button>
+    </ion-buttons>
+
+    <ion-title text-center>Scoping Session</ion-title>
+  </ion-toolbar>
 </ion-header>
 
 <ion-content>

--- a/src/features/scoping/pages/session-scoping/session-scoping.component.scss
+++ b/src/features/scoping/pages/session-scoping/session-scoping.component.scss
@@ -1,4 +1,7 @@
 app-session-scoping {
+  // .back-button {
+  //   display: inherit;
+  // }
   .session-info-container {
     margin: 30px;
   }

--- a/src/features/scoping/pages/session-scoping/session-scoping.component.scss
+++ b/src/features/scoping/pages/session-scoping/session-scoping.component.scss
@@ -1,7 +1,4 @@
 app-session-scoping {
-  // .back-button {
-  //   display: inherit;
-  // }
   .session-info-container {
     margin: 30px;
   }


### PR DESCRIPTION
The user was getting trapped when navigating to the scoping flow from the share-scope-link-modal.
The user could not go to the dashboard. Added a back button that always returns to the dashboard.